### PR TITLE
fix(fastlane): use store-safe markup in app descriptions

### DIFF
--- a/fastlane/metadata/com.akylas.cardwallet/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/com.akylas.cardwallet/android/fr-FR/full_description.txt
@@ -1,10 +1,10 @@
 <i>OSS Portefeuille</i> est une application Open Source pour scanner et stocker toutes vos cartes. Vous numérisez soit en utilisant votre caméra, soit en important une image. L'application détecte automatiquement les cartes et codes-barres dans la photo et va recadrer l'image.
 
-* Détection automatique du code barre/QRCode
-* Ajoutez manuellement le code barre/QRCode
-* utilisez l'OCR pour stocker du contenu pour un accès facile / copie
-* Sécurisez vos données avec la biométrie
-* partagez / exportez en PDF / images. Vous pouvez même le faire pour plusieurs documents à la fois
-* imprimez directement depuis votre téléphone!
-* Raccourcis pour les cartes récemment utilisées pour un accès facile
-* afficher rapidement le code barre/QRCode pour un scan facile
+• Détection automatique du code barre/QRCode
+• Ajoutez manuellement le code barre/QRCode
+• utilisez l'OCR pour stocker du contenu pour un accès facile / copie
+• Sécurisez vos données avec la biométrie
+• partagez / exportez en PDF / images. Vous pouvez même le faire pour plusieurs documents à la fois
+• imprimez directement depuis votre téléphone!
+• Raccourcis pour les cartes récemment utilisées pour un accès facile
+• afficher rapidement le code barre/QRCode pour un scan facile

--- a/fastlane/metadata/com.akylas.cardwallet/ios/en-US/description.txt
+++ b/fastlane/metadata/com.akylas.cardwallet/ios/en-US/description.txt
@@ -1,51 +1,51 @@
-<i>OSS Card Wallet</i> is a free and Open Source app to transform your mobile device into a powerful card scanner and wallet
+OSS Card Wallet is a free and Open Source app to transform your mobile device into a powerful card scanner and wallet
 
-<b>SCAN</b>
+SCAN
 • Scan your IDs, business cards, loyalty cards with a fast camera scan.
 • Enjoy the automatic edge detection feature allowing you to quickly scan many documents
 • Bulk scan to quickly add recto/verso
 • Import cards from images or even existing PDF
 
-<b>BARCODE</b>
+BARCODE
 • automatic detection of barcodes, qrcodes...
 • manually create a card with a barcode
 • add as many barcodes as you want to a simple card
 
-<b>PASSBOOK</b>
+PASSBOOK
 • Full Passbook support
 • import from .pkpass
 • view your Passbooks as you would in the official Apple Passbook App
 • Export and share your passbooks as .pkpass or PDF
 
-<b>ENHANCE</b>
+ENHANCE
 • Improve PDFs quality by applying enhancing filters for color or black & white cards.
 • Edit crop
 • Reorder pages, merge cards
 • Rotate pages
 • Change brightness and contrast to create beautiful cards
 
-<b>ORGANIZE</b>
+ORGANIZE
 • Create folders with colors for easy access
 • Sort cards
 • Name cards
 
-<b>EXPORT</b>
+EXPORT
 • create PDF directly from your mobile device by converting photos, images, other documents, into beautiful and configurable PDFs.
 • export and share your cards to PDF or JPEG or PNG with your friends, family, colleagues
 
-<b>SEARCH</b>
+SEARCH
 • OCR your cards using offline (to be downloaded first) and open source models in many languages.
 • Generate searchable PDFs by converting images to text using the powerful OCR models from the Tesseract project.
 
-<b>SECURITY</b>
+SECURITY
 • Improve the security of your generated PDF by adding a password.
 
-<b>SYNC</b>
+SYNC
 • Synchronize your cards, PDFs, Images with your computers, other devices or local folder sync.
 • Sync using WebDAV, Google Drive, OneDrive
 
-<b>PRIVACY</b>
+PRIVACY
 • Use a free and Open Source card wallet to protect your privacy
 
-<b>COMMUNITY</b>
+COMMUNITY
 • Provide feedback or even help translate the app. You are part of this project and you make help it grow so that everyone can enjoy the best free and open source card wallet

--- a/fastlane/metadata/com.akylas.documentscanner/android/de-DE/full_description.txt
+++ b/fastlane/metadata/com.akylas.documentscanner/android/de-DE/full_description.txt
@@ -1,1 +1,5 @@
-<p>Der <i>OSS Document Scanner</i> ist eine Open-Source-App zum Scannen all Ihrer Dokumente. Sie scannen entweder mit Ihrer Kamera oder importieren ein Bild. Die App erkennt Ihr Dokument automatisch im Foto und schneidet das Bild zu.</p><p>Sobald das Dokument erstellt ist, können Sie mithilfe von OCR Text im Dokument erkennen lassen.</p><p>Sie können Ihr Dokument auch als PDF teilen. Wenn Sie möchten, können Sie die App-Daten mit einem WebDAV-Server (wie Nextloud) synchronisieren, um nie etwas zu verlieren!</p>
+Der <i>OSS Document Scanner</i> ist eine Open-Source-App zum Scannen all Ihrer Dokumente. Sie scannen entweder mit Ihrer Kamera oder importieren ein Bild. Die App erkennt Ihr Dokument automatisch im Foto und schneidet das Bild zu.
+
+Sobald das Dokument erstellt ist, können Sie mithilfe von OCR Text im Dokument erkennen lassen.
+
+Sie können Ihr Dokument auch als PDF teilen. Wenn Sie möchten, können Sie die App-Daten mit einem WebDAV-Server (wie Nextloud) synchronisieren, um nie etwas zu verlieren!

--- a/fastlane/metadata/com.akylas.documentscanner/android/en-US/full_description.txt
+++ b/fastlane/metadata/com.akylas.documentscanner/android/en-US/full_description.txt
@@ -1,41 +1,41 @@
 The OSS Document Scanner is a free and Open Source app to transform your mobile device into a powerful document scanner.
 
-SCAN
-* Scan your documents or receipts with a fast camera scan.
-* Enjoy the automatic edge detection feature allowing you to quickly scan many documents
-* Bulk scan documents or book pages
-* Import documents from images or even existing PDF
-* You can scan to PDF any kind of document: Receipts, IDs, notes, recipes, photos, business cards, whiteboards, books. You can then use and work with the generated PDFs on all your devices, phones, computers, tablets...
+<b>SCAN</b>
+• Scan your documents or receipts with a fast camera scan.
+• Enjoy the automatic edge detection feature allowing you to quickly scan many documents
+• Bulk scan documents or book pages
+• Import documents from images or even existing PDF
+• You can scan to PDF any kind of document: Receipts, IDs, notes, recipes, photos, business cards, whiteboards, books. You can then use and work with the generated PDFs on all your devices, phones, computers, tablets...
 
-ENHANCE
-* Improve PDFs quality by applying enhancing filters for color or black & white documents.
-* Edit crop
-* Reorder pages, merge documents
-* Rotate pages
-* Change brightness and contrast to create beautiful documents
+<b>ENHANCE</b>
+• Improve PDFs quality by applying enhancing filters for color or black & white documents.
+• Edit crop
+• Reorder pages, merge documents
+• Rotate pages
+• Change brightness and contrast to create beautiful documents
 
-ORGANIZE
-* Create folders with colors for easy access
-* Sort documents
-* Name documents
+<b>ORGANIZE</b>
+• Create folders with colors for easy access
+• Sort documents
+• Name documents
 
-EXPORT
-* create PDF directly from your mobile device by converting photos, images, other documents, into beautiful and configurable PDFs.
-* export and share your documents to PDF or JPEG or PNG with your friends, family, colleagues
+<b>EXPORT</b>
+• create PDF directly from your mobile device by converting photos, images, other documents, into beautiful and configurable PDFs.
+• export and share your documents to PDF or JPEG or PNG with your friends, family, colleagues
 
-SEARCH
-* OCR your documents using offline (to be downloaded first) and open source models in many languages.
-* Generate searchable PDFs by converting images to text using the powerful OCR models from the Tesseract project.
+<b>SEARCH</b>
+• OCR your documents using offline (to be downloaded first) and open source models in many languages.
+• Generate searchable PDFs by converting images to text using the powerful OCR models from the Tesseract project.
 
-SECURITY
-* Improve the security of your generated PDF by adding a password.
+<b>SECURITY</b>
+• Improve the security of your generated PDF by adding a password.
 
-SYNC
-* Synchronize your documents, PDFs, Images with your computers, other devices or local folder sync.
-* Sync using WebDAV, Google Drive, OneDrive
+<b>SYNC</b>
+• Synchronize your documents, PDFs, Images with your computers, other devices or local folder sync.
+• Sync using WebDAV, Google Drive, OneDrive
 
-PRIVACY
-* Use a free and Open Source document scanner to protect your privacy
+<b>PRIVACY</b>
+• Use a free and Open Source document scanner to protect your privacy
 
-COMMUNITY
-* Provide feedback or even help translate the app. You are part of this project and you make help it grow so that everyone can enjoy the best free and open source document scanner
+<b>COMMUNITY</b>
+• Provide feedback or even help translate the app. You are part of this project and you make help it grow so that everyone can enjoy the best free and open source document scanner

--- a/fastlane/metadata/com.akylas.documentscanner/android/fr-FR/full_description.txt
+++ b/fastlane/metadata/com.akylas.documentscanner/android/fr-FR/full_description.txt
@@ -1,1 +1,5 @@
-<p>L'application <i>OSS Docs Scanneur</i> est une application Open Source pour scanner tous vos documents. Soit vous scannez à l'aide de votre appareil photo, soit vous importez une image. L'application détecte automatiquement dans la photo et recadre l'image.</p><p>Une fois le document créé, vous pouvez détecter du texte dans le document en utilisant l'OCR.</p><p>Vous pouvez également partager votre document en format PDF. Si vous voulez, vous pouvez synchroniser les données de l'application avec un serveur WebDAV (comme Nextcloud) pour ne jamais rien perdre !</p>
+L'application <i>OSS Docs Scanneur</i> est une application Open Source pour scanner tous vos documents. Soit vous scannez à l'aide de votre appareil photo, soit vous importez une image. L'application détecte automatiquement dans la photo et recadre l'image.
+
+Une fois le document créé, vous pouvez détecter du texte dans le document en utilisant l'OCR.
+
+Vous pouvez également partager votre document en format PDF. Si vous voulez, vous pouvez synchroniser les données de l'application avec un serveur WebDAV (comme Nextcloud) pour ne jamais rien perdre !

--- a/fastlane/metadata/com.akylas.documentscanner/ios/en-US/description.txt
+++ b/fastlane/metadata/com.akylas.documentscanner/ios/en-US/description.txt
@@ -1,1 +1,41 @@
-Scan documents, tickets, bills, cards ...  anything you want!Then you can detect text in them, share the detected text or the whole document as a PDF.The whole app is open source!
+The OSS Document Scanner is a free and Open Source app to transform your mobile device into a powerful document scanner.
+
+SCAN
+• Scan your documents or receipts with a fast camera scan.
+• Enjoy the automatic edge detection feature allowing you to quickly scan many documents
+• Bulk scan documents or book pages
+• Import documents from images or even existing PDF
+• You can scan to PDF any kind of document: Receipts, IDs, notes, recipes, photos, business cards, whiteboards, books. You can then use and work with the generated PDFs on all your devices, phones, computers, tablets...
+
+ENHANCE
+• Improve PDFs quality by applying enhancing filters for color or black & white documents.
+• Edit crop
+• Reorder pages, merge documents
+• Rotate pages
+• Change brightness and contrast to create beautiful documents
+
+ORGANIZE
+• Create folders with colors for easy access
+• Sort documents
+• Name documents
+
+EXPORT
+• create PDF directly from your mobile device by converting photos, images, other documents, into beautiful and configurable PDFs.
+• export and share your documents to PDF or JPEG or PNG with your friends, family, colleagues
+
+SEARCH
+• OCR your documents using offline (to be downloaded first) and open source models in many languages.
+• Generate searchable PDFs by converting images to text using the powerful OCR models from the Tesseract project.
+
+SECURITY
+• Improve the security of your generated PDF by adding a password.
+
+SYNC
+• Synchronize your documents, PDFs, Images with your computers, other devices or local folder sync.
+• Sync using WebDAV, Google Drive, OneDrive
+
+PRIVACY
+• Use a free and Open Source document scanner to protect your privacy
+
+COMMUNITY
+• Provide feedback or even help translate the app. You are part of this project and you make help it grow so that everyone can enjoy the best free and open source document scanner


### PR DESCRIPTION
## Summary

Store descriptions are shared between renderers that do **not** support the same markup, so the files
now stick to the subset that works everywhere.

- **Android** (`full_description.txt`, both apps): section headers use `<b>`, bullets use `•`, sections
  are separated by blank lines. No `<ul>`/`<li>` (Google Play does not render them) and no `<p>`
  (unsupported on both Play and F-Droid). This also removes the `<p>` markup that `fr-FR` and `de-DE`
  were shipping to Play.
- **iOS** (`description.txt`): now mirrors the android `en-US` content, in plain text — App Store
  Connect renders no markup at all. The `com.akylas.cardwallet` iOS description did not exist and was
  added.
- Wording is unchanged everywhere; only markup and bullet characters were touched.

Why the subset: F-Droid supports `b/i/u/br/ul/ol/li/…` and converts every newline to `<br>`, while
Google Play only supports `b/i/u/br` plus entities. The intersection is `<b>`, `<i>`, `<u>`, `<br>`,
literal bullet characters and blank-line paragraphs.

## Testing

Metadata only — no app code touched, so no unit tests or `svelte-check` apply. Checked:

- every description under the 4000-char store limit (largest is 2061)
- no `<p>`/`<ul>`/`<li>`/`<h*>` left in any `full_description.txt`
- no markup at all in either iOS `description.txt`
- normalized diff confirms no wording changed

Actual store rendering can only be confirmed at the next release (`upload_store` / `deliver` with
`upload_metadata`, and the next F-Droid/IzzyOnDroid build).

Refs #682