### PR TITLE
fix(pdf): apply color filters when exporting to PDF on android

### DIFF
--- a/plugin-nativeprocessor/platforms/android/java/com/akylas/documentscanner/utils/PDFUtils.kt
+++ b/plugin-nativeprocessor/platforms/android/java/com/akylas/documentscanner/utils/PDFUtils.kt
@@ -256,14 +256,17 @@ class PDFUtils {
                     )
             }
             finalBitmapOptions.inMutable = colorMatrix != null
-            val bmp = BitmapFactory.decodeFile(src, finalBitmapOptions) ?: return null
+            var bmp = BitmapFactory.decodeFile(src, finalBitmapOptions) ?: return null
             if (hasColorMatrix) {
                 val jsonArray = JSONArray(colorMatrix)
                 val floatArray = Array(jsonArray.length()) { jsonArray.getDouble(it).toFloat() }
-                val canvas = android.graphics.Canvas(bmp)
+                val filteredBmp = Bitmap.createBitmap(bmp.width, bmp.height, bmp.config ?: Bitmap.Config.ARGB_8888)
+                val canvas = android.graphics.Canvas(filteredBmp)
                 val paint = Paint()
                 paint.colorFilter = ColorMatrixColorFilter(floatArray.toFloatArray())
                 canvas.drawBitmap(bmp, 0F, 0F, paint)
+                bmp.recycle()
+                bmp = filteredBmp
             }
 
             val imgBytes = ByteArrayOutputStream()


### PR DESCRIPTION
## Summary

Exported PDFs kept the original page colors even when a color adjustment (grayscale, b&w, sepia, invert, polaroid, or a brightness/contrast tweak — anything that produces a non-null `colorMatrix`) was applied in the app before exporting. Other adjustments like "improve" go through a different path and were unaffected. The linked issue reports it for grayscale/b&w specifically, but the bug is in the shared `colorMatrix` application, so it affects any filter/adjustment.

`loadImage()` in `PDFUtils.kt` applies the page's colorMatrix by building a `Canvas` backed by the same bitmap it then draws onto:

```kotlin
val canvas = android.graphics.Canvas(bmp)
canvas.drawBitmap(bmp, 0F, 0F, paint)
```

Source and destination bitmap being identical is undefined behavior on Android, so the color filter never reliably made it into the encoded output. Render into a separate bitmap instead and swap references.

## Testing

- Built a debug APK from this branch and installed it on a physical device: scanned a page, applied grayscale/b&w, exported to PDF — the exported PDF now correctly shows the filtered colors (previously showed the original colors).

Refs #695