### PR TITLE
fix(common): decode the crop view image at screen resolution

### DIFF
--- a/app/components/common/CropView.svelte
+++ b/app/components/common/CropView.svelte
@@ -1,11 +1,11 @@
 <script context="module" lang="ts">
     import { BitmapShader, Canvas, CanvasView, Matrix, Paint, Path, Style, TileMode } from '@nativescript-community/ui-canvas';
-    import { ApplicationSettings, ImageSource, Screen, TouchGestureEventData, Utils } from '@nativescript/core';
+    import { ApplicationSettings, ImageSource, TouchGestureEventData, Utils } from '@nativescript/core';
     import { debounce } from '@nativescript/core/utils';
     import { QRCodeData, QuadPoint, Quads } from 'plugin-nativeprocessor';
     import { onDestroy } from 'svelte';
     import { NativeViewElementNode } from '@nativescript-community/svelte-native/dom';
-    import { MAGNIFIER_SENSITIVITY, SETTINGS_MAGNIFIER_SENSITIVITY } from '~/utils/constants';
+    import { IMAGE_DECODE_HEIGHT, MAGNIFIER_SENSITIVITY, SETTINGS_MAGNIFIER_SENSITIVITY } from '~/utils/constants';
     import { loadImage, recycleImages } from '~/utils/images';
     import { showError } from '@shared/utils/showError';
     import { createEventDispatcher } from '@shared/utils/svelte/ui';
@@ -14,7 +14,8 @@
     import { colorTheme, isEInk } from '~/helpers/theme';
     const padding = 20;
     const ZOOOM_GLASS_SIZE = 50;
-    const ZOOM_IMAGE_MAX_SIZE = Math.max(Screen.mainScreen.widthDIPs, Screen.mainScreen.heightDIPs);
+    // in pixels: it is used as a decode size, both for `loadImage` and for the image view
+    const ZOOM_IMAGE_MAX_SIZE = IMAGE_DECODE_HEIGHT;
 
     declare namespace svelteNative.JSX {
         interface ViewAttributes {


### PR DESCRIPTION
## Summary

`CropView` derived its decode size from `Screen.mainScreen.widthDIPs`/`heightDIPs`, but that value reaches decoders that expect **pixels**: `decodeWidth` ends up in Fresco's `ResizeOptions`, and the magnifier's `loadImage({ resizeThreshold })` goes to the native processor. On a 1080x2340 screen the image was decoded at 780px and then upscaled to fill the view, so the photo shown right after a capture looked markedly blurrier than the camera preview it replaces — even though the captured file itself is sharp.

- Reuse `IMAGE_DECODE_HEIGHT` (`widthPixels`/`heightPixels`), which is already what the rest of the app passes as a decode size. On a 1080x2340 device that is 780 -> 2340.
- The magnifier loupe reads the same constant, so it sharpens too.

Note this decodes ~9x more pixels for that one bitmap, which is what every other image view in the app already does.

## Testing

- `npx eslint` clean, `svelte-check` reports 0 errors
- built and installed on a Galaxy S22 (SM-S901U1); the blur was traced there with the actual files: the capture pulled off the device (4080x3060) is sharp at 1:1, the crop geometry is correct, and only the on-screen decode was undersized

A visual confirmation on device that the review screen now matches the preview's sharpness is still worth doing.